### PR TITLE
Allow specifying if a package does not support ZTS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ The descriptions of these items:
  * The `php-ext` is a new top-level element to provide additional metadata for building the extension, if required.
    * Proposed JSON schema for this is in [composer-json-php-ext-schema.json](./composer-json-php-ext-schema.json)
    * It is assumed that packages all support Zend Thread Safe mode (ZTS). If a package does **not** support ZTS mode,
-     the key `"support-zts": false` should be set in `php-ext` section
+     the key `"support-zts": false` should be set in `php-ext` section, but you may explicitly advertise ZTS support by
+     specifying `"support-zts": true`.
 
 ## End user: installing a PIE package
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Create a `composer.json` in your repository, commit:
     },
     "php-ext": {
         "priority": 80,
+        "support-zts": false,
         "configure-options": [
             {
                 "name": "enable-xdebug-dev",
@@ -222,6 +223,8 @@ The descriptions of these items:
  * Typically, there will be almost no `require` definitions, except `php` version itself
  * The `php-ext` is a new top-level element to provide additional metadata for building the extension, if required.
    * Proposed JSON schema for this is in [composer-json-php-ext-schema.json](./composer-json-php-ext-schema.json)
+   * It is assumed that packages all support Zend Thread Safe mode (ZTS). If a package does **not** support ZTS mode,
+     the key `"support-zts": false` should be set in `php-ext` section
 
 ## End user: installing a PIE package
 
@@ -249,6 +252,9 @@ sequenceDiagram
    this missing depenedency, and warn accordingly.
  * whilst it would be useful for end users, library requirements will not currently be factored into the `composer.json`
    dependencies, due to the complexity of different package managers on different platforms.
+ * The package will be checked to see if it is compatible with ZTS mode. If using a `--with-php-config` with ZTS
+   enabled, but the extension specifies `"support-zts": false` in its `composer.json` manifest, the installation will
+   be halted with an error explanation.
 
 Once we have the release information, for Linux:
 

--- a/composer-json-php-ext-schema.json
+++ b/composer-json-php-ext-schema.json
@@ -17,6 +17,12 @@
                     "example": 80,
                     "default": 80
                 },
+                "support-zts": {
+                    "type": "boolean",
+                    "description": "Does this package support Zend Thread Safety",
+                    "example": false,
+                    "default": true
+                },
                 "configure-options": {
                     "type": "array",
                     "description": "These configure options make up the flags that can be passed to ./configure when installing the extension.",


### PR DESCRIPTION
@derickr mentioned that some packages do not support ZTS mode. Therefore this proposal adds a `php-ext.support-zts` option which can be disabled. If PIE is used to install on a PHP platform that is ZTS, but the extension is not ZTS compatible, an error will be raised.